### PR TITLE
Fix WhatsApp button overflow

### DIFF
--- a/src/presentation/components/layout/default/default.module.scss
+++ b/src/presentation/components/layout/default/default.module.scss
@@ -3,6 +3,7 @@
 
 .whatsapp-button {
   @include display-flex;
+  overflow: hidden;
   background-color: $color-success;
   box-shadow: rgba(0, 0, 0, 0.15) 0 0.25rem 0.75rem;
   transition: transform 0.3s;
@@ -35,8 +36,8 @@
   }
   .icon {
     color: $color-snow;
-    width: 11rem;
-    height: 11rem;
+    width: 2.5rem;
+    height: 2.5rem;
     padding: 0.5rem;
   }
 }

--- a/src/presentation/pages/home/home.module.scss
+++ b/src/presentation/pages/home/home.module.scss
@@ -3,7 +3,7 @@
 
 .whatsapp-button {
     @include display-flex;
-    overflow-x: hidden !important;
+    overflow: hidden;
     background-color: $color-success;
     box-shadow: rgba(0, 0, 0, 0.15) 0 0.25rem 0.75rem;
     transition: transform 0.3s;
@@ -40,8 +40,8 @@
 
     .icon {
         color: $color-snow;
-        width: 11rem;
-        height: 11rem;
+        width: 2.5rem;
+        height: 2.5rem;
         padding: 0.5rem;
     }
 }


### PR DESCRIPTION
## Summary
- fix WhatsApp button icon size to remove scrollbar
- hide overflow in the floating button container

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68877f8d75408323bd702474f8563a09